### PR TITLE
Fix two production-blocking bugs: registration UI and lesson page inf…

### DIFF
--- a/client/src/pages/active-lesson-page.tsx
+++ b/client/src/pages/active-lesson-page.tsx
@@ -22,26 +22,39 @@ const ActiveLessonPage = () => {
   const { selectedLearner } = useMode();
   const [isLoading, setIsLoading] = useState(true);
 
+  // Use context learnerId, falling back to localStorage if context hasn't hydrated yet
+  const learnerId = selectedLearner?.id ?? (() => {
+    if (typeof window !== 'undefined') {
+      const stored = window.localStorage.getItem('selectedLearnerId');
+      return stored ? parseInt(stored, 10) : undefined;
+    }
+    return undefined;
+  })();
+
   const {
     data: lesson,
     error,
     isLoading: queryLoading,
+    fetchStatus,
   } = useQuery({
-    queryKey: ['/api/lessons/active', selectedLearner?.id],
-    queryFn: () => apiRequest('GET', `/api/lessons/active?learnerId=${selectedLearner?.id}`).then(res => res.data),
-    enabled: !!selectedLearner?.id,
+    queryKey: ['/api/lessons/active', learnerId],
+    queryFn: () => apiRequest('GET', `/api/lessons/active?learnerId=${learnerId}`).then(res => res.data),
+    enabled: !!learnerId,
     retry: 1,
   });
 
   useEffect(() => {
-    // Simulate content loading delay
     if (!queryLoading && lesson) {
       const timer = setTimeout(() => {
         setIsLoading(false);
       }, 500);
       return () => clearTimeout(timer);
     }
-  }, [queryLoading, lesson]);
+    // If query is disabled (no learnerId at all) and not fetching, stop showing spinner
+    if (!learnerId && fetchStatus === 'idle') {
+      setIsLoading(false);
+    }
+  }, [queryLoading, lesson, learnerId, fetchStatus]);
 
   const handleStartQuiz = () => {
     if (lesson) {

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -105,6 +105,54 @@ export async function setupAuth(app: Express) {
     }
   }));
 
+  // Registration endpoint (mirrors /register from routes.ts for /api/ prefix consistency)
+  app.post("/api/register", asyncHandler(async (req: Request, res: Response) => {
+    try {
+      const { username, email, name, role, password } = req.body;
+
+      if (!username || !email || !name || !role || !password) {
+        return res.status(400).json({ error: "Missing required fields" });
+      }
+
+      if (!["ADMIN", "PARENT", "LEARNER"].includes(role)) {
+        return res.status(400).json({ error: "Invalid role" });
+      }
+
+      const existingUser = await storage.getUserByUsername(username);
+      if (existingUser) {
+        return res.status(409).json({ error: "Username already exists" });
+      }
+
+      const userCountResult = await db.select({ count: count() }).from(users);
+      const isFirstUser = userCountResult[0].count === 0;
+      const effectiveRole = isFirstUser ? "ADMIN" : role;
+
+      const hashedPassword = await hashPassword(password);
+      const newUser = await storage.createUser({
+        username,
+        email,
+        name,
+        role: effectiveRole as any,
+        password: hashedPassword,
+      });
+
+      const token = generateToken({ id: newUser.id, role: newUser.role });
+      const { password: _, ...userWithoutPassword } = newUser;
+
+      return res.json({
+        token,
+        user: userWithoutPassword,
+        wasPromotedToAdmin: isFirstUser && role !== "ADMIN",
+      });
+    } catch (error: any) {
+      console.error('Registration error:', error);
+      if (error.code === '23505') {
+        return res.status(409).json({ error: "Username or email already exists" });
+      }
+      return res.status(500).json({ error: 'Registration failed. Please try again.' });
+    }
+  }));
+
   // Enhanced user info endpoint with cross-domain support
   app.get("/api/user", authenticateJwt, asyncHandler(async (req: AuthRequest, res: Response) => {
     // Log the request info for debugging


### PR DESCRIPTION
…inite spinner

Bug 1 - Registration UI 'unexpected server response':
  Root cause: Client posts to /api/register (use-auth.tsx), but server only
  had POST /register (routes.ts). The /api/register path fell through to the
  catch-all serving index.html. Client got HTML instead of JSON.
  Fix: Added POST /api/register route in server/auth.ts (mirrors the existing
  /api/login pattern from the same file).

Bug 2 - Lesson page infinite loading spinner:
  Root cause: active-lesson-page.tsx query depends on selectedLearner?.id from
  ModeContext. When context hasn't hydrated yet (async chain: auth → learners
  query → localStorage restore), selectedLearner is null, enabled is false,
  and React Query v5 keeps isLoading=true for disabled queries — infinite spin.
  Fix: Added localStorage fallback for learnerId so the query fires even before
  context hydrates. Also detect when query is disabled (no learnerId at all)
  and stop showing the spinner.