### PR TITLE
Fix reports bugs, auth branding, per-question double-or-nothing

### DIFF
--- a/client/src/pages/auth-page.tsx
+++ b/client/src/pages/auth-page.tsx
@@ -140,10 +140,30 @@ const AuthPage = () => {
       <ScrollView contentContainerStyle={styles.scrollContent}>
         <View style={styles.headerContainer}>
           <View style={styles.logoContainer} aria-hidden="true">
-            <Book size={48} color={colors.primary} aria-hidden="true" />
+            <svg width="56" height="56" viewBox="0 0 32 32" aria-hidden="true" focusable="false">
+              <defs>
+                <linearGradient id="authSunG" x1="0%" y1="0%" x2="100%" y2="100%">
+                  <stop offset="0%" stopColor="#F5A623" />
+                  <stop offset="100%" stopColor="#F97316" />
+                </linearGradient>
+              </defs>
+              <circle cx="16" cy="16" r="8" fill="url(#authSunG)" />
+              <circle cx="16" cy="16" r="6" fill="none" stroke="#fff" strokeWidth="0.5" opacity="0.3" />
+              <circle cx="16" cy="16" r="2" fill="#fff" opacity="0.6" />
+              <g stroke="#F5A623" strokeWidth="2" strokeLinecap="round" opacity="0.7">
+                <line x1="16" y1="5" x2="16" y2="2" />
+                <line x1="16" y1="27" x2="16" y2="30" />
+                <line x1="5" y1="16" x2="2" y2="16" />
+                <line x1="27" y1="16" x2="30" y2="16" />
+                <line x1="8.2" y1="8.2" x2="6" y2="6" />
+                <line x1="23.8" y1="8.2" x2="26" y2="6" />
+                <line x1="8.2" y1="23.8" x2="6" y2="26" />
+                <line x1="23.8" y1="23.8" x2="26" y2="26" />
+              </g>
+            </svg>
           </View>
           <Text style={styles.title} accessibilityRole="header">SUNSCHOOL</Text>
-          <Text style={styles.subtitle}>The Open Source AI Tutor</Text>
+          <Text style={styles.subtitle}>School — anywhere under the sun.</Text>
         </View>
         
         <View style={styles.tabContainer} accessibilityRole="tablist">
@@ -441,8 +461,6 @@ const styles = StyleSheet.create({
   logoContainer: {
     width: 80,
     height: 80,
-    borderRadius: 40,
-    backgroundColor: colors.primaryLight,
     justifyContent: 'center',
     alignItems: 'center',
     marginBottom: 16,

--- a/client/src/pages/quiz-page.tsx
+++ b/client/src/pages/quiz-page.tsx
@@ -6,7 +6,6 @@ import {
   TouchableOpacity,
   ScrollView,
   SafeAreaView,
-  Switch,
   Modal,
 } from 'react-native';
 import { useQuery, useMutation } from '@tanstack/react-query';
@@ -50,8 +49,11 @@ const QuizPage = ({ params }: { params?: { lessonId?: string } }) => {
   const [showConfetti, setShowConfetti] = useState(false);
   const [showAchievements, setShowAchievements] = useState(false);
   const [quizStarted, setQuizStarted] = useState(false);
-  const [doubleOrLoss, setDoubleOrLoss] = useState(false);
   const [showDelegation, setShowDelegation] = useState(false);
+  // Per-question double-or-loss: tracks which question indices the kid chose to double
+  const [doubleQuestions, setDoubleQuestions] = useState<Set<number>>(new Set());
+  // Tracks which 3rd questions the kid has decided on (chosen double or skip)
+  const [doubleDecided, setDoubleDecided] = useState<Set<number>>(new Set());
   const [quizScore, setQuizScore] = useState<{
     score: number;
     correctCount: number;
@@ -60,6 +62,7 @@ const QuizPage = ({ params }: { params?: { lessonId?: string } }) => {
     pointsAwarded: number;
     pointsDeducted: number;
     doubleOrLoss: boolean;
+    doubleQuestionIndices?: number[];
     newBalance: number;
     newAchievements: any[];
   } | null>(null);
@@ -96,7 +99,10 @@ const QuizPage = ({ params }: { params?: { lessonId?: string } }) => {
   // Submit answers mutation
   const submitAnswersMutation = useMutation({
     mutationFn: (answers: number[]) => {
-      return apiRequest('POST', `/api/lessons/${lessonId}/answer`, { answers, doubleOrLoss }).then(res => res.data);
+      return apiRequest('POST', `/api/lessons/${lessonId}/answer`, {
+        answers,
+        doubleQuestionIndices: Array.from(doubleQuestions),
+      }).then(res => res.data);
     },
     onSuccess: (data) => {
       setQuizSubmitted(true);
@@ -289,7 +295,7 @@ const QuizPage = ({ params }: { params?: { lessonId?: string } }) => {
         <View style={{ width: 24 }} />
       </View>
 
-      {/* ── Pre-quiz screen (double-or-loss toggle) ── */}
+      {/* ── Pre-quiz screen ── */}
       {!quizStarted && !quizSubmitted && (
         <ScrollView contentContainerStyle={styles.scrollContent}>
           <View style={[styles.preQuizCard, { backgroundColor: theme.colors.surfaceColor }]}>
@@ -301,26 +307,21 @@ const QuizPage = ({ params }: { params?: { lessonId?: string } }) => {
             </Text>
 
             {dolAllowedByParent && (
-              <View style={[styles.dolCard, { borderColor: doubleOrLoss ? '#FF8F00' : theme.colors.divider }]}>
+              <View style={[styles.dolCard, { borderColor: '#FF8F00' }]}>
                 <View style={styles.dolHeader}>
                   <Zap size={20} color="#FF8F00" />
-                  <Text style={[styles.dolTitle, { color: theme.colors.textPrimary }]}>Double-or-Loss Mode</Text>
-                  <Switch value={doubleOrLoss} onValueChange={setDoubleOrLoss} trackColor={{ true: '#FF8F00' }} />
+                  <Text style={[styles.dolTitle, { color: theme.colors.textPrimary }]}>Double-or-Nothing Active</Text>
                 </View>
                 <Text style={[styles.dolDesc, { color: theme.colors.textSecondary }]}>
-                  {doubleOrLoss
-                    ? '⚡ ON — 2× points for correct, −1 point for wrong!'
-                    : 'OFF — Standard scoring (1 point per correct answer)'}
+                  Every 3rd question you can go for double points — or skip and play it safe!
                 </Text>
               </View>
             )}
 
             <TouchableOpacity
-              style={[styles.startBtn, { backgroundColor: doubleOrLoss ? '#FF8F00' : theme.colors.primary }]}
+              style={[styles.startBtn, { backgroundColor: theme.colors.primary }]}
               onPress={handleStartQuiz}>
-              <Text style={styles.startBtnText}>
-                {doubleOrLoss ? '⚡ Start Double-or-Loss!' : 'Start Quiz →'}
-              </Text>
+              <Text style={styles.startBtnText}>Start Quiz</Text>
             </TouchableOpacity>
           </View>
         </ScrollView>
@@ -416,16 +417,24 @@ const QuizPage = ({ params }: { params?: { lessonId?: string } }) => {
 
             <View style={styles.reviewSection}>
               <Text style={[styles.reviewTitle, { color: theme.colors.textPrimary }]}>Let's Review</Text>
-              {displayQuestions.map((question, index) => (
-                <QuizComponent
-                  key={index}
-                  question={question}
-                  selectedAnswer={selectedAnswers[index]}
-                  showAnswers={true}
-                  onSelectAnswer={() => {}}
-
-                />
-              ))}
+              {displayQuestions.map((question, index) => {
+                const wasDoubled = quizScore?.doubleQuestionIndices?.includes(index);
+                return (
+                  <View key={index}>
+                    {wasDoubled && (
+                      <View style={[styles.dolBadge, { backgroundColor: '#FFF3E0', marginBottom: 4 }]}>
+                        <Text style={styles.dolBadgeText}><Zap size={12} color="#FF8F00" /> Double-or-Nothing</Text>
+                      </View>
+                    )}
+                    <QuizComponent
+                      question={question}
+                      selectedAnswer={selectedAnswers[index]}
+                      showAnswers={true}
+                      onSelectAnswer={() => {}}
+                    />
+                  </View>
+                );
+              })}
             </View>
 
             <TouchableOpacity style={[styles.continueButton, { backgroundColor: theme.colors.success }]} onPress={handleContinue}>
@@ -442,20 +451,71 @@ const QuizPage = ({ params }: { params?: { lessonId?: string } }) => {
               Let's see what you learned! Answer each question below.
             </Text>
 
-            {displayQuestions.map((question, index) => (
-              <View key={index} style={styles.questionContainer}>
-                <Text style={[styles.questionNumber, { color: theme.colors.textSecondary }]}>
-                  Question {index + 1} of {displayQuestions.length}
-                </Text>
-                <QuizComponent
-                  question={question}
-                  selectedAnswer={selectedAnswers[index]}
-                  showAnswers={false}
-                  onSelectAnswer={(answerIndex) => handleSelectAnswer(index, answerIndex)}
+            {displayQuestions.map((question, index) => {
+              const isDoubleEligible = dolAllowedByParent && (index + 1) % 3 === 0;
+              const hasDecided = doubleDecided.has(index);
+              const isDoubled = doubleQuestions.has(index);
 
-                />
-              </View>
-            ))}
+              return (
+                <View key={index} style={styles.questionContainer}>
+                  <Text style={[styles.questionNumber, { color: theme.colors.textSecondary }]}>
+                    Question {index + 1} of {displayQuestions.length}
+                    {isDoubled && ' — 2x'}
+                  </Text>
+
+                  {/* Double-or-nothing prompt on every 3rd question */}
+                  {isDoubleEligible && !hasDecided && (
+                    <View style={styles.dolPrompt}>
+                      <View style={styles.dolPromptHeader}>
+                        <Zap size={18} color="#FF8F00" />
+                        <Text style={styles.dolPromptTitle}>Double or Nothing?</Text>
+                      </View>
+                      <Text style={styles.dolPromptDesc}>
+                        Get 2x points if correct, lose 1 point if wrong.
+                      </Text>
+                      <View style={styles.dolPromptButtons}>
+                        <TouchableOpacity
+                          style={styles.dolGoBtn}
+                          onPress={() => {
+                            setDoubleQuestions(prev => new Set(prev).add(index));
+                            setDoubleDecided(prev => new Set(prev).add(index));
+                          }}
+                        >
+                          <Zap size={14} color="#fff" />
+                          <Text style={styles.dolGoBtnText}>Go for it!</Text>
+                        </TouchableOpacity>
+                        <TouchableOpacity
+                          style={styles.dolSkipBtn}
+                          onPress={() => {
+                            setDoubleDecided(prev => new Set(prev).add(index));
+                          }}
+                        >
+                          <Text style={styles.dolSkipBtnText}>Play it safe</Text>
+                        </TouchableOpacity>
+                      </View>
+                    </View>
+                  )}
+
+                  {/* Show badge after decision */}
+                  {isDoubleEligible && hasDecided && (
+                    <View style={[styles.dolBadge, { backgroundColor: isDoubled ? '#FFF3E0' : theme.colors.background }]}>
+                      {isDoubled ? (
+                        <Text style={styles.dolBadgeText}><Zap size={12} color="#FF8F00" /> Double-or-Nothing!</Text>
+                      ) : (
+                        <Text style={[styles.dolBadgeText, { color: theme.colors.textSecondary }]}>Playing it safe</Text>
+                      )}
+                    </View>
+                  )}
+
+                  <QuizComponent
+                    question={question}
+                    selectedAnswer={selectedAnswers[index]}
+                    showAnswers={false}
+                    onSelectAnswer={(answerIndex) => handleSelectAnswer(index, answerIndex)}
+                  />
+                </View>
+              );
+            })}
 
             <TouchableOpacity
               style={[styles.submitButton, {
@@ -691,6 +751,75 @@ const styles = StyleSheet.create({
   delegationFill: { height: '100%', borderRadius: 4 },
   skipDelegation: {
     borderWidth: 1, borderRadius: 10, paddingVertical: 12, alignItems: 'center', marginTop: 8,
+  },
+  // Double-or-nothing per-question prompt
+  dolPrompt: {
+    backgroundColor: '#FFF8E1',
+    borderWidth: 2,
+    borderColor: '#FF8F00',
+    borderRadius: 12,
+    padding: 14,
+    marginBottom: 12,
+  },
+  dolPromptHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginBottom: 4,
+  },
+  dolPromptTitle: {
+    fontSize: 16,
+    fontWeight: '800',
+    color: '#E65100',
+  },
+  dolPromptDesc: {
+    fontSize: 13,
+    color: '#795548',
+    marginBottom: 10,
+  },
+  dolPromptButtons: {
+    flexDirection: 'row',
+    gap: 10,
+  },
+  dolGoBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    backgroundColor: '#FF8F00',
+    paddingVertical: 10,
+    paddingHorizontal: 18,
+    borderRadius: 10,
+  },
+  dolGoBtnText: {
+    color: '#fff',
+    fontWeight: '800',
+    fontSize: 14,
+  },
+  dolSkipBtn: {
+    paddingVertical: 10,
+    paddingHorizontal: 18,
+    borderRadius: 10,
+    borderWidth: 1.5,
+    borderColor: '#BDBDBD',
+  },
+  dolSkipBtnText: {
+    color: '#757575',
+    fontWeight: '700',
+    fontSize: 14,
+  },
+  dolBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    borderRadius: 8,
+    alignSelf: 'flex-start',
+    marginBottom: 8,
+  },
+  dolBadgeText: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: '#E65100',
   },
 });
 

--- a/client/src/pages/reports-page.tsx
+++ b/client/src/pages/reports-page.tsx
@@ -288,7 +288,7 @@ const ReportsPage: React.FC = () => {
                             <Text style={styles.achievementTitle}>{achievement.title}</Text>
                             <Text style={styles.achievementDescription}>{achievement.description}</Text>
                             <Text style={styles.achievementDate}>
-                              Earned on {new Date(achievement.createdAt).toLocaleDateString()}
+                              Earned on {(achievement.awardedAt ? new Date(achievement.awardedAt).toLocaleDateString() : 'Unknown date')}
                             </Text>
                           </View>
                         </View>

--- a/client/src/pages/welcome-page.tsx
+++ b/client/src/pages/welcome-page.tsx
@@ -326,7 +326,7 @@ const WelcomePage: React.FC = () => {
         <View style={styles.finalCta}>
           <View style={styles.finalCtaInner}>
             <Text style={styles.finalCtaTitle} accessibilityRole="header">
-              School starts when{'\n'}the sun does.
+              School {'\u2014'} anywhere{'\n'}under the sun.
             </Text>
             <Text style={styles.finalCtaNote}>Free forever for core features. No credit card needed.</Text>
             <TouchableOpacity style={styles.finalCtaButton} onPress={goToAuth} accessibilityRole="button" accessibilityLabel="Get Started Free">

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1054,7 +1054,7 @@ export function registerRoutes(app: Express): Server {
     }
 
     const lessonId = req.params.lessonId;
-    const { answers, doubleOrLoss: doubleOrLossFlag } = req.body;
+    const { answers, doubleOrLoss: doubleOrLossFlag, doubleQuestionIndices } = req.body;
 
     if (!Array.isArray(answers)) {
       return res.status(400).json({ error: "Answers must be an array" });
@@ -1160,11 +1160,29 @@ export function registerRoutes(app: Express): Server {
       });
     }
 
-    // After score calculation — award points with optional Double-or-Loss multiplier
+    // After score calculation — award points with per-question Double-or-Loss
     const wrongCount = questions.length - correctCount;
-    const isDoubleOrLoss = doubleOrLossFlag === true;
-    const pointsPerCorrect = isDoubleOrLoss ? 2 : 1;
-    const pointsAwarded = correctCount * pointsPerCorrect;
+
+    // Support both legacy whole-quiz flag and new per-question indices
+    const perQuestionDoubles: Set<number> = new Set(
+      Array.isArray(doubleQuestionIndices) ? doubleQuestionIndices : []
+    );
+    const isLegacyDoubleOrLoss = doubleOrLossFlag === true && perQuestionDoubles.size === 0;
+
+    let pointsAwarded = 0;
+    let pointsDeducted = 0;
+
+    for (let i = 0; i < questions.length; i++) {
+      const isCorrect = answers[i] === questions[i].correctIndex;
+      const isDoubled = isLegacyDoubleOrLoss || perQuestionDoubles.has(i);
+      if (isCorrect) {
+        pointsAwarded += isDoubled ? 2 : 1;
+      } else if (isDoubled) {
+        pointsDeducted += 1;
+      }
+    }
+
+    const hasAnyDouble = isLegacyDoubleOrLoss || perQuestionDoubles.size > 0;
 
     let newBalance = 0;
     try {
@@ -1174,14 +1192,14 @@ export function registerRoutes(app: Express): Server {
           amount: pointsAwarded,
           sourceType: "QUIZ_CORRECT",
           sourceId: lessonId,
-          description: `Quiz ${score}%${isDoubleOrLoss ? ' [Double-or-Loss ×2]' : ''}`
+          description: `Quiz ${score}%${hasAnyDouble ? ' [Double-or-Loss]' : ''}`
         });
       }
 
-      // Double-or-Loss deduction for wrong answers
-      if (isDoubleOrLoss && wrongCount > 0) {
+      // Double-or-Loss deduction for wrong answers on doubled questions
+      if (pointsDeducted > 0) {
         const { applyDoubleOrLossDeduction } = await import('./services/rewards-service');
-        await applyDoubleOrLossDeduction(learnerId, wrongCount);
+        await applyDoubleOrLossDeduction(learnerId, pointsDeducted);
       }
 
       newBalance = await pointsService.getBalance(learnerId);
@@ -1196,8 +1214,9 @@ export function registerRoutes(app: Express): Server {
       totalQuestions: questions.length,
       wrongCount,
       pointsAwarded,
-      pointsDeducted: isDoubleOrLoss ? wrongCount : 0,
-      doubleOrLoss: isDoubleOrLoss,
+      pointsDeducted,
+      doubleOrLoss: hasAnyDouble,
+      doubleQuestionIndices: Array.from(perQuestionDoubles),
       newBalance,
       newAchievements: newAchievements.map(a => a.payload)
     });
@@ -1328,6 +1347,16 @@ export function registerRoutes(app: Express): Server {
         // Calculate subject performance if available
         let subjectPerformance = profile?.subjectPerformance || {};
 
+        // Get concept mastery count from the mastery service
+        let conceptsLearnedCount = 0;
+        try {
+          const { getMasterySummary } = await import('./services/mastery-service');
+          const masterySummary = await getMasterySummary(Number(learnerId));
+          conceptsLearnedCount = masterySummary.totalConcepts;
+        } catch (e) {
+          console.error('Error fetching mastery summary for report:', e);
+        }
+
         // Calculate additional analytics
         const analytics = {
           lessonsCompleted: completedLessons,
@@ -1335,7 +1364,7 @@ export function registerRoutes(app: Express): Server {
           lessonsQueued: queuedLessons,
           totalLessons: lessons.length,
           achievementsCount: achievements.length,
-          conceptsLearned: profile?.graph?.nodes?.length || 0,
+          conceptsLearned: conceptsLearnedCount,
           progressRate: lessons.length > 0 ? (completedLessons / lessons.length) * 100 : 0,
           subjectDistribution: {} as Record<string, number>
         };


### PR DESCRIPTION
## Summary
- **Reports: concepts learned** — was showing 0 because it read from empty `profile.graph.nodes`. Now queries `concept_mastery` table via mastery service.
- **Reports: achievement dates** — was showing "Invalid Date" because code used `createdAt` instead of the schema field `awardedAt`.
- **Auth page** — updated with orange sun logo and "School — anywhere under the sun." tagline to match landing page rebrand.
- **CTA text** — fixed final CTA from "School starts when the sun does." to "School — anywhere under the sun."
- **Double-or-nothing rework** — changed from whole-quiz on/off toggle to per-question choice every 3rd question. When parent enables the setting, every 3rd question shows a "Double or Nothing?" prompt where the kid can go for 2x points (risking -1 for wrong) or play it safe. Server supports both legacy and new per-question scoring.

## Test plan
- [ ] Verify `/reports` shows correct concepts learned count
- [ ] Verify achievements show correct dates (not "Invalid Date")
- [ ] Verify `/auth` page shows orange sun logo and tagline
- [ ] Enable double-or-loss in parent settings, start a quiz as learner
- [ ] Confirm every 3rd question (Q3, Q6, Q9...) shows the double-or-nothing prompt
- [ ] Confirm choosing "Go for it!" applies 2x scoring on that question
- [ ] Confirm choosing "Play it safe" uses normal scoring
- [ ] Confirm results screen shows which questions were doubled

🤖 Generated with [Claude Code](https://claude.com/claude-code)