### PR TITLE
fix: SVG lesson images + expand all sections

### DIFF
--- a/client/src/components/EnhancedLessonContent.tsx
+++ b/client/src/components/EnhancedLessonContent.tsx
@@ -290,7 +290,7 @@ const EnhancedLessonContent: React.FC<EnhancedLessonContentProps> = ({ enhancedS
           key={index}
           title={section.title}
           icon={getSectionIcon(section.type)}
-          defaultExpanded={index === 0}
+          defaultExpanded={true}
           accentColor={theme.colors.primary}
         >
           {/* Section Images */}

--- a/server/config/env.ts
+++ b/server/config/env.ts
@@ -57,7 +57,7 @@ export const BITTENSOR_WALLET_HOTKEY = process.env.BITTENSOR_WALLET_HOTKEY;
 export const PERPLEXITY_API_KEY = process.env.PERPLEXITY_API_KEY || '';
 
 // Image Generation Configuration
-export const IMAGE_PROVIDER = process.env.IMAGE_PROVIDER || 'openrouter'; // 'openrouter' | 'svg-llm' | 'stability'
+export const IMAGE_PROVIDER = process.env.IMAGE_PROVIDER || 'svg-llm'; // 'svg-llm' | 'openrouter' | 'stability'
 export const OPENROUTER_IMAGE_MODEL = process.env.OPENROUTER_IMAGE_MODEL || 'google/gemini-3.1-pro-preview';
 export const OPENROUTER_SVG_MODEL = process.env.OPENROUTER_SVG_MODEL || 'google/gemini-3.1-pro-preview';
 export const IMAGE_GENERATION_TIMEOUT = parseInt(process.env.IMAGE_GENERATION_TIMEOUT || '15000');


### PR DESCRIPTION
## Summary
- Switch default `IMAGE_PROVIDER` to `svg-llm` — generates topic-relevant SVG illustrations via Gemini 3.1
- Previously `openrouter` generated wrong-content raster images (e.g. atom diagram in a fractions lesson)
- Expand all lesson accordion sections by default so all images are visible

## Test plan
- [ ] Generate a new lesson and verify SVG illustrations are topic-relevant
- [ ] All sections should be expanded showing their images

🤖 Generated with [Claude Code](https://claude.com/claude-code)