### PR TITLE
Fix: handle 402 credit errors in model fallback chains

### DIFF
--- a/server/services/openrouter-image-service.ts
+++ b/server/services/openrouter-image-service.ts
@@ -96,8 +96,9 @@ export async function generateEducationalImage(
 
       console.warn(`[OpenRouter Image] Model ${model} returned no image data, trying next`);
     } catch (error: any) {
-      const is404 = axios.isAxiosError(error) && error.response?.status === 404;
-      const isUnavailable = is404 || (error.message || '').includes('No endpoints found');
+      const status = axios.isAxiosError(error) ? error.response?.status : undefined;
+      const msg = error.message || '';
+      const isUnavailable = status === 404 || status === 402 || msg.includes('No endpoints found') || msg.includes('not available') || msg.includes('credits') || msg.includes('afford');
 
       if (isUnavailable && model !== models[models.length - 1]) {
         console.warn(`[OpenRouter Image] Model ${model} unavailable, trying next fallback`);

--- a/server/services/svg-llm-service.ts
+++ b/server/services/svg-llm-service.ts
@@ -10,10 +10,10 @@ function getSvgModelChain(): string[] {
   return [OPENROUTER_SVG_MODEL, ...fallbacks];
 }
 
-/** Returns true for errors that indicate the model itself is unavailable */
+/** Returns true for errors that indicate the model should be skipped (unavailable or over budget) */
 function isModelUnavailable(error: any): boolean {
   const msg = error?.message || '';
-  return msg.includes('404') || msg.includes('No endpoints found') || msg.includes('not available');
+  return msg.includes('404') || msg.includes('402') || msg.includes('No endpoints found') || msg.includes('not available') || msg.includes('credits') || msg.includes('afford');
 }
 
 /**
@@ -166,7 +166,7 @@ export async function generateEducationalSVG(
         messages,
         model,
         temperature: 0.3,
-        max_tokens: 4000,
+        max_tokens: 1500,
       });
 
       const rawSvg = response.choices[0]?.message?.content;
@@ -224,7 +224,7 @@ export async function generateDiagramSVG(
         messages,
         model,
         temperature: 0.3,
-        max_tokens: 4000,
+        max_tokens: 1500,
       });
 
       const rawSvg = response.choices[0]?.message?.content;


### PR DESCRIPTION
## Summary
- Both `svg-llm-service.ts` and `openrouter-image-service.ts` now treat 402 (insufficient credits) as "model unavailable", allowing fallback to cheaper models instead of aborting
- Reduced SVG `max_tokens` from 4000 to 1500 to stay within credit limits

## Test plan
- [ ] Deploy to Railway and generate a lesson
- [ ] Verify SVG illustrations render (not placeholder text)
- [ ] Run Playwright E2E suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)