### PR TITLE
fix: reject non-whitelisted origins in CORS configuration

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -41,14 +41,15 @@ export async function setupAuth(app: Express) {
       const { username, password } = req.body;
       
       // Determine the request origin for CORS handling
-      const origin = req.headers.origin || req.headers.referer || 'unknown';
-      let isSunschool = false;
-      try {
-        const parsedOrigin = new URL(origin);
-        isSunschool = parsedOrigin.hostname === 'sunschool.xyz' || parsedOrigin.hostname.endsWith('.sunschool.xyz');
-      } catch (_e) { /* ignore invalid origin URL */ }
-      // For sunschool.xyz domain, add special CORS headers for authentication
-      if (isSunschool) {
+      const origin = req.headers.origin || '';
+      const allowedAuthOrigins = [
+        'https://sunschool.xyz',
+        'https://www.sunschool.xyz',
+        'http://localhost:5000',
+        'http://localhost:3000'
+      ];
+      // For explicitly allowed origins, add CORS headers for authentication
+      if (allowedAuthOrigins.includes(origin)) {
         res.header('Access-Control-Allow-Origin', origin);
         res.header('Access-Control-Allow-Credentials', 'true');
         res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS');
@@ -82,7 +83,7 @@ export async function setupAuth(app: Express) {
       return res.json({
         token,
         user: userWithoutPassword,
-        domain: isSunschool ? 'sunschool.xyz' : origin.split('://')[1]?.split(':')[0] || 'unknown'
+        domain: allowedAuthOrigins.includes(origin) && origin.includes('sunschool.xyz') ? 'sunschool.xyz' : new URL(origin || 'http://unknown').hostname
       });
     } catch (error) {
       console.error('Authentication endpoint error:', error);
@@ -145,15 +146,16 @@ export async function setupAuth(app: Express) {
 
   // Enhanced user info endpoint with cross-domain support
   app.get("/api/user", authenticateJwt, asyncHandler(async (req: AuthRequest, res: Response) => {
-    const origin = req.headers.origin || req.headers.referer || 'unknown';
-    let isSunschool = false;
-    try {
-      const parsedOrigin = new URL(origin);
-      isSunschool = parsedOrigin.hostname === 'sunschool.xyz' || parsedOrigin.hostname.endsWith('.sunschool.xyz');
-    } catch (_e) { /* ignore invalid origin URL */ }
+    const origin = req.headers.origin || '';
+    const allowedAuthOrigins = [
+      'https://sunschool.xyz',
+      'https://www.sunschool.xyz',
+      'http://localhost:5000',
+      'http://localhost:3000'
+    ];
 
-    if (isSunschool) {
-      // Add special CORS headers for sunschool.xyz domain
+    if (allowedAuthOrigins.includes(origin)) {
+      // Add CORS headers for explicitly allowed origins
       res.header('Access-Control-Allow-Origin', origin);
       res.header('Access-Control-Allow-Credentials', 'true');
       res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS');

--- a/server/index.ts
+++ b/server/index.ts
@@ -72,17 +72,16 @@ app.use(cors({
     // Define allowed origins
     const allowedOrigins = [
       'https://sunschool.xyz',
-      'http://sunschool.xyz',
       'https://www.sunschool.xyz',
       'http://localhost:5000',
       'http://localhost:3000'
     ];
     
     // Check if the request origin is in our allowed list
-    if (allowedOrigins.indexOf(origin) !== -1 || origin.includes('replit.dev')) {
+    if (allowedOrigins.indexOf(origin) !== -1) {
       callback(null, true);
     } else {
-      callback(null, true);
+      callback(new Error('Not allowed by CORS'));
     }
   },
   credentials: true,

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -135,20 +135,21 @@ export async function authenticateJwt(req: AuthRequest, res: Response, next: Nex
   }
   
   // Determine origin for CORS handling
-  const origin = req.headers.origin || req.headers.referer || 'unknown';
-  let isSunschool = false;
-  try {
-    const parsedOrigin = new URL(origin);
-    isSunschool = parsedOrigin.hostname === 'sunschool.xyz' || parsedOrigin.hostname.endsWith('.sunschool.xyz');
-  } catch (_e) { /* ignore invalid origin URL */ }
-  
+  const origin = req.headers.origin || '';
+  const allowedAuthOrigins = [
+    'https://sunschool.xyz',
+    'https://www.sunschool.xyz',
+    'http://localhost:5000',
+    'http://localhost:3000'
+  ];
+
   if (!token) {
     res.status(401).json({ error: 'No authorization token provided' });
     return;
   }
-  
-  // For sunschool.xyz domain, add CORS headers to ensure the response works
-  if (isSunschool) {
+
+  // For explicitly allowed origins, add CORS headers to ensure the response works
+  if (allowedAuthOrigins.includes(origin)) {
     res.header('Access-Control-Allow-Origin', origin);
     res.header('Access-Control-Allow-Credentials', 'true');
     res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS');

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -208,11 +208,16 @@ export function registerRoutes(app: Express): Server {
     try {
       const { username, password } = req.body;
       
-      const origin = req.headers.origin || req.headers.referer || 'unknown';
-      const isSunschool = origin.includes('sunschool.xyz');
+      const origin = req.headers.origin || '';
+      const allowedAuthOrigins = [
+        'https://sunschool.xyz',
+        'https://www.sunschool.xyz',
+        'http://localhost:5000',
+        'http://localhost:3000'
+      ];
 
-      // For sunschool.xyz domain, add special CORS headers for authentication
-      if (isSunschool) {
+      // For explicitly allowed origins, add CORS headers for authentication
+      if (allowedAuthOrigins.includes(origin)) {
         res.header('Access-Control-Allow-Origin', origin);
         res.header('Access-Control-Allow-Credentials', 'true');
         res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS');
@@ -247,7 +252,7 @@ export function registerRoutes(app: Express): Server {
       return res.json({
         token,
         user: userWithoutPassword,
-        domain: isSunschool ? 'sunschool.xyz' : origin.split('://')[1]?.split(':')[0] || 'unknown'
+        domain: allowedAuthOrigins.includes(origin) && origin.includes('sunschool.xyz') ? 'sunschool.xyz' : new URL(origin || 'http://unknown').hostname
       });
     } catch (error) {
       console.error('Authentication endpoint error:', error);


### PR DESCRIPTION
## Summary
- Fix CORS bypass in `server/index.ts` where the else branch always returned `true`, effectively disabling CORS
- Replace dynamic origin echoing in `server/auth.ts` with explicit whitelist
- Tighten subdomain check to only allow known subdomains
- Fix CORS headers in `server/middleware/auth.ts` and `server/routes.ts`

## Security Impact
- **CRITICAL**: Previously any origin could make authenticated cross-origin requests
- Now only explicitly whitelisted origins are allowed
- See decision log el-r2g5 for rationale

## Test plan
- [ ] Verify sunschool.xyz can still make API requests
- [ ] Verify non-whitelisted origins receive CORS rejection
- [ ] Check no regressions on auth flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)