### PR TITLE
fix: cast json to jsonb in migration COALESCE to fix type mismatch

### DIFF
--- a/drizzle/migrations/0008_unify_spec.sql
+++ b/drizzle/migrations/0008_unify_spec.sql
@@ -21,7 +21,7 @@ SET spec = jsonb_build_object(
       'type', 'key_concepts'
     )
   ),
-  'questions', COALESCE(spec->'questions', '[]'::jsonb),
+  'questions', COALESCE((spec->'questions')::jsonb, '[]'::jsonb),
   'images', '[]'::jsonb,
   'diagrams', '[]'::jsonb,
   'keywords', '[]'::jsonb,


### PR DESCRIPTION
## Summary
- Fix CI migration failure: `COALESCE could not convert type jsonb to json`
- In `0008_unify_spec.sql`, the `spec` column is `JSON` type but the COALESCE fallback was `'[]'::jsonb`
- Fix: explicitly cast `(spec->'questions')::jsonb` so both COALESCE args are `jsonb`

## Root cause
`spec` is defined as `JSON` (not `JSONB`) in the initial migration. `spec->'questions'` returns `json`, but `'[]'::jsonb` is `jsonb`. PostgreSQL requires COALESCE arguments to have matching types.

## Test plan
- [ ] CI migration passes
- [ ] Unblocks merging of PRs #23, #28, #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)